### PR TITLE
Implement inclusive multi-level cache hierarchy

### DIFF
--- a/cache_base/cache_base.h
+++ b/cache_base/cache_base.h
@@ -75,6 +75,14 @@ public:
   void print_stats();
   void dump_tag_store(bool is_file);  // false: dump to stdout, true: dump to a file
 
+  // invalidate the cacheline if present; return true if invalidated
+  bool invalidate(addr_t address, bool* was_dirty = nullptr);
+
+  // install a write-back line without touching LRU stack
+  bool install_writeback(addr_t address,
+                         addr_t *evict_addr = nullptr,
+                         bool   *evict_dirty = nullptr);
+
 private:
   std::string m_name;     // cache name
   int m_num_sets;         // number of sets

--- a/cache_base/run_base.cc
+++ b/cache_base/run_base.cc
@@ -23,7 +23,7 @@ void process_trace(cache_base_c* cache, const char* name) {
   if (trace_file.is_open()) {
     while (std::getline(trace_file, line)) {
       std::sscanf(line.c_str(), "%d %lx", &type, &address);
-        cache->access(address, type, 1);
+      cache->access(address, type, 0);
     }
   }
 }


### PR DESCRIPTION
## Summary
- implement invalidation helper and write-back insertion API in cache base
- propagate back invalidations from L2 to both L1 caches
- forward store misses correctly and install write-back lines without touching LRU
- build split L1I/L1D caches and inclusive L2 in the memory hierarchy
- fix run_base to count cache accesses correctly

## Testing
- `make`
- `./memory_sim ./traces/sample.trace ./configs/memory.cfg`
- `./cache_base/run_base ./traces/sample.trace 8192 2 64`


------
https://chatgpt.com/codex/tasks/task_e_6842ab570868832aa33a68a430a959c4